### PR TITLE
Update DBRS memcached centos8 dockerfile

### DIFF
--- a/dbrs/centos8/memcached/Dockerfile
+++ b/dbrs/centos8/memcached/Dockerfile
@@ -1,9 +1,9 @@
 FROM centos as builder
 RUN dnf update -y && \
     dnf install gcc make perl libevent-devel curl -y
-RUN curl -LO https://www.memcached.org/files/memcached-1.5.21.tar.gz && \
-    tar -zxvf memcached-1.5.21.tar.gz && \
-    cd memcached-1.5.21 && \
+RUN curl -LO https://www.memcached.org/files/memcached-1.6.2.tar.gz && \
+    tar -zxvf memcached-1.6.2.tar.gz && \
+    cd memcached-1.6.2 && \
     ./configure --prefix=/usr/local/memcached  && make && make test && make install
 
 FROM centos

--- a/dbrs/releasenote.md
+++ b/dbrs/releasenote.md
@@ -35,12 +35,12 @@ The release includes:
 The release includes:
 
   * Clear Linux* OS
-  * Memcached 1.5.21 with persistent memory restartable cache
+  * Memcached 1.6.2 with persistent memory restartable cache
 
 and
 
   * CentOS 8 OS
-  * Memcached 1.5.21 with persistent memory restartable cache
+  * Memcached 1.6.2 with persistent memory restartable cache
 
 ## How to get the Database Reference Stack
 


### PR DESCRIPTION
As part of the DBRSv0.2.1 release, it includes a version bump of memcached version
to 1.6.2 wich contains an important security fix. ClearLinux's dockerfile was not
updated as it pulls memcached from a bundle and we do not manage the versioning
under this approach, but as today, the Clear Linux OS contains a memcached 1.6.2+
version.

Signed-off-by: Gabriel Briones Sayeg <gabriel.briones.sayeg@intel.com>