### PR TITLE
mers: remove old  non required config file.

### DIFF
--- a/mers/clearlinux/dnf.conf
+++ b/mers/clearlinux/dnf.conf
@@ -1,4 +1,0 @@
-[clearlinux]
-name=clearlinux
-baseurl=https://cdn.download.clearlinux.org/releases/$releasever/clear/x86_64/os/
-gpgcheck=0


### PR DESCRIPTION
DNF was just a temp solution that at the end it was replaced by CLR
bundles, so no need to have a dnf’s conf file